### PR TITLE
added alt url support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.8 (2017-06-16)
+
+Updates:
+
+  - added alternate URL support
+
 ## 0.0.6 (2017-03-03)
 
 Updates:

--- a/README.md
+++ b/README.md
@@ -12,11 +12,18 @@ A node.js wrapper for the [Alice App API](http://developer.aliceapp.com/).
 `npm install alice-app`
 
 ##Usage
-### Initialization
+### Standard Initialization (defaults to `https://rest.aliceapp.com`)
 ```javascript
 var Alice = require('alice-app');
 alice = new Alice('YOUR API KEY', 'YOUR AUTHENTICATION KEY');
 ```
+
+### Standard Initialization with alternate API URL
+```javascript
+var Alice = require('alice-app');
+alice = new Alice('YOUR API KEY', 'YOUR AUTHENTICATION KEY', 'ALTERNATE API URL');
+```
+
 ### Tickets
 #### Get
 Request:

--- a/lib/alice.js
+++ b/lib/alice.js
@@ -1,19 +1,21 @@
 'use strict'
 const fetch = require('node-fetch');
+var defaultAliceURL = 'rest.aliceapp.com'
 
 class Alice {
-    constructor(key, auth) {
+    constructor(key, auth, url) {
         if (!key) {
             return new Error("An API key is required");
         }
         if (!auth) {
             return new Error("An Auth key is required");
         }
-        this.contentType = 'application/json'
-        this.hostname = 'rest.aliceapp.com/staff/v1/hotels/'
-        this.apiKey = 'apikey=' + key
-        this.protocol = 'http://'
-        this.auth = "Basic " + auth;
+        this.apiURL = url || defaultAliceURL
+        this.contentType = 'application/json';
+        this.hostname = `${this.apiURL}/staff/v1/hotels/`;
+        this.apiKey = `apikey=${key}`;
+        this.protocol = 'https://';
+        this.auth = `Basic ${auth}`;
         this.methods = {
             events: {
                 getByHotel(params) {
@@ -137,7 +139,7 @@ class Alice {
     }
     request(action, params) {
         const type = action.type;
-        let url = `http://rest.aliceapp.com/staff/v1/${action.endpoint}`;
+        let url = `${this.protocol}${this.apiURL}/staff/v1/${action.endpoint}`;
         if (url.includes('?')) {
             url += `&${this.apiKey}`
         } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alice-app",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "JS wrapper for the Alice App API",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -16,6 +16,16 @@ describe('Testing Initialization Failure', function() {
         expect(alice).to.be.an.instanceof(Error);
     })
 })
+describe('Testing default and alternate API URLs', function() {
+    it('Should default to rest.aliceapp.com', function() {
+        let alice = new Alice(123456, 78910)
+        expect(alice.apiURL).to.equal("rest.aliceapp.com")
+    })
+    it('Should allow replacing the url', function() {
+        let alice = new Alice(123456, 78910, "rapi.aliceapp.com")
+        expect(alice.apiURL).to.equal("rapi.aliceapp.com")
+    })
+})
 describe('Testing Exports', function() {
     beforeEach(function() {
         var apiKey = 123456;
@@ -64,7 +74,7 @@ describe('Testing Exports', function() {
                     "name": "declined",
                     "abbreviation": "DEC"
                 }];
-                nock('http://rest.aliceapp.com/staff/v1')
+                nock('https://rest.aliceapp.com/staff/v1')
                     .get('/hotels/1/workflowStates?apikey=123456')
                     .reply(200, getResponse);
             })
@@ -89,7 +99,7 @@ describe('Testing Exports', function() {
                     "websocketUrl": "wss://www.aliceapp.com/555",
                     "longPollingUrl": "https://www.aliceapp.com/555"
                 };
-                nock('http://rest.aliceapp.com/staff/v1')
+                nock('https://rest.aliceapp.com/staff/v1')
                     .get('/hotelGroups/40/events?apikey=123456')
                     .reply(200, getResponse);
             })
@@ -106,7 +116,7 @@ describe('Testing Exports', function() {
                     "websocketUrl": "wss://www.aliceapp.com/555",
                     "longPollingUrl": "https://www.aliceapp.com/555"
                 };
-                nock('http://rest.aliceapp.com/staff/v1')
+                nock('https://rest.aliceapp.com/staff/v1')
                     .get('/hotels/202/events?apikey=123456')
                     .reply(200, getResponse);
             })
@@ -123,7 +133,7 @@ describe('Testing Exports', function() {
                     "websocketUrl": "wss://www.aliceapp.com/555",
                     "longPollingUrl": "https://www.aliceapp.com/555"
                 };
-                nock('http://rest.aliceapp.com/staff/v1')
+                nock('https://rest.aliceapp.com/staff/v1')
                     .get('/hotels/202/reservations/xxx-ggg-xxx/events?apikey=123456')
                     .reply(200, getResponse);
             })
@@ -157,7 +167,7 @@ describe('Testing Exports', function() {
                     }],
                     "price": 0
                 }];
-                nock('http://rest.aliceapp.com/staff/v1')
+                nock('https://rest.aliceapp.com/staff/v1')
                     .get('/hotels/1/facilities/2/services?apikey=123456')
                     .reply(200, getResponse);
             })
@@ -267,7 +277,7 @@ describe('Testing Exports', function() {
                         "name": "string"
                     }
                 };
-                nock('http://rest.aliceapp.com/staff/v1')
+                nock('https://rest.aliceapp.com/staff/v1')
                     .get('/hotels/1/tickets/0?apikey=123456')
                     .reply(200, getResponse);
             })
@@ -295,7 +305,7 @@ describe('Testing Exports', function() {
                 var createResponse = {
                     id: 0
                 };
-                nock('http://rest.aliceapp.com/staff/v1')
+                nock('https://rest.aliceapp.com/staff/v1')
                     .post('/hotels/1/tickets/serviceRequest?apikey=123456')
                     .reply(200, createResponse);
             })
@@ -342,7 +352,7 @@ describe('Testing Exports', function() {
         })
         describe('Update Ticket', function() {
             beforeEach(function() {
-                nock('http://rest.aliceapp.com/staff/v1')
+                nock('https://rest.aliceapp.com/staff/v1')
                     .put('/hotels/1/tickets/2/serviceRequest?apikey=123456')
                     .reply(204, "success");
             })
@@ -389,7 +399,7 @@ describe('Testing Exports', function() {
         })
         describe('Update Status', function() {
             beforeEach(function() {
-                nock('http://rest.aliceapp.com/staff/v1')
+                nock('https://rest.aliceapp.com/staff/v1')
                     .put('/hotels/1/tickets/2/workflowState?apikey=123456')
                     .reply(204, "success");
             })
@@ -516,10 +526,10 @@ describe('Testing Exports', function() {
                         "name": "string"
                     }
                 }];
-                nock('http://rest.aliceapp.com/staff/v1')
+                nock('https://rest.aliceapp.com/staff/v1')
                     .get('/hotels/1/tickets?ticketTypes=ServiceRequest&apikey=123456')
                     .reply(200, searchResponse);
-                nock('http://rest.aliceapp.com/staff/v1')
+                nock('https://rest.aliceapp.com/staff/v1')
                     .get('/hotels/1/tickets?query=airport&ticketTypes=ServiceRequest&apikey=123456')
                     .reply(200, searchResponse);
             });


### PR DESCRIPTION
I needed to add alternate URL support for our sandbox environment. Included changes:

- Version bump to 0.0.8
- Change-log update
- Readme update
- added `url` to constructor, making it optional, and defaulting to old behavior
- replaced hard-coded urls with better abstractions
- replaced all `http` with `https` (because friends don't let friend clear-text)
- added tests for default `url` behavior as well as alternate `url` behavior